### PR TITLE
Make the db migration stuff more explicit

### DIFF
--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -115,8 +115,8 @@ else
     echo "--------------------------------------------------------------"
     sleep 5
     cd ${DATA_DIR}/CSMM
-    timeout 120 nodejs ${DATA_DIR}/CSMM/app.js
     export NODE_ENV=production
+    npm run db:migrate
 fi
 sleep 3
 screen -S BackupDatabase -L -d -m /opt/scripts/backup-database.sh


### PR DESCRIPTION
Create a new script to reduce support requests that will create the DB and exit, so no need to do a timeout and guess.

https://github.com/CatalysmsServerManager/7-days-to-die-server-manager/pull/106